### PR TITLE
[POUPEAI-62] Implementar Mixins para reaproveitar dados compartilhados

### DIFF
--- a/apps/poupeai/mixins.py
+++ b/apps/poupeai/mixins.py
@@ -1,0 +1,12 @@
+from django.urls import reverse_lazy
+
+class BreadcrumbMixin:
+    breadcrumbs = []
+
+    def get_breadcrumbs(self):
+        return self.breadcrumbs
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["breadcrumbs"] = self.get_breadcrumbs()
+        return context

--- a/apps/poupeai/mixins.py
+++ b/apps/poupeai/mixins.py
@@ -10,3 +10,14 @@ class BreadcrumbMixin:
         context = super().get_context_data(**kwargs)
         context["breadcrumbs"] = self.get_breadcrumbs()
         return context
+
+class PageNameMixin:
+    name = ""
+
+    def get_name(self):
+        return self.name
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["name"] = self.get_name()
+        return context

--- a/apps/poupeai/models/__init__.py
+++ b/apps/poupeai/models/__init__.py
@@ -1,8 +1,8 @@
 from .account import Account
-from .goal import Goal, GoalDeposit
 from .category import Category
-from .transaction import Transaction, CardTransaction, AccountTransaction
-from .creditcard import Brand, CreditCard, Invoice
+from .creditcard import CreditCard, Brand, Invoice
+from .goal import Goal, GoalDeposit
+from .transaction import Transaction, AccountTransaction, CardTransaction
 
 __all__ = [
     'Account',

--- a/apps/poupeai/models/transaction.py
+++ b/apps/poupeai/models/transaction.py
@@ -1,6 +1,7 @@
 from django.db import models
 from apps.authentication.models import CustomUser
-from apps.poupeai.models import Category, Account
+from .account import Account
+from .category import Category
 from .creditcard import CreditCard, Invoice
 
 TRANSACTION_TYPES = (

--- a/apps/poupeai/urls.py
+++ b/apps/poupeai/urls.py
@@ -4,7 +4,7 @@ from .views import *
 urlpatterns = [
     path('', home_view, name='home'),
     path('dashboard/', dashboard_view, name='dashboard'),
-    path('categories/', categories_view, name='categories'),
+    path('categories/', CategoriesView.as_view(), name='categories'),
     path('transactions/', transactions_view, name='transactions'),
     path('accounts/', accounts_view, name='accounts'),
     path('credit-card/', creditcard_view, name='credit-card'),

--- a/apps/poupeai/views/__init__.py
+++ b/apps/poupeai/views/__init__.py
@@ -1,5 +1,5 @@
 from .accounts import accounts_view
-from .categories import categories_view
+from .categories import CategoriesView
 from .creditcard import creditcard_view
 from .dashboard import dashboard_view
 from .help import help_view
@@ -14,7 +14,7 @@ from .notifications import *
 __all__ = [
     'home_view',
     'accounts_view',
-    'categories_view',
+    'CategoriesView',
     'creditcard_view',
     'dashboard_view',
     'help_view',

--- a/apps/poupeai/views/categories.py
+++ b/apps/poupeai/views/categories.py
@@ -1,47 +1,47 @@
-from django.shortcuts import render
+from django.views.generic import TemplateView
 from django.urls import reverse_lazy
+from apps.poupeai.mixins import BreadcrumbMixin
 
-def categories_view(request):
-    categories_despesas = [
-        {"id": 1, "nome": "Aluguel", "valor": 1000.50, "cor": "#ff0000"},
-        {"id": 2, "nome": "Supermercado de Arroz", "valor": 500.00, "cor": "#00ff00"},
-        {"id": 3, "nome": "Transporte", "valor": 150.00, "cor": "#ff6600"},
-        {"id": 4, "nome": "Internet", "valor": 120.00, "cor": "#00ffff"},
-        {"id": 5, "nome": "Saúde", "valor": 300.00, "cor": "#ff99cc"},
-    ]
+class CategoriesView(BreadcrumbMixin, TemplateView):
+    template_name = "categories.html"
+    
+    def get_breadcrumbs(self):
+        return [
+            {"name": "Dashboard", "url": reverse_lazy('dashboard')},
+            {"name": "Categorias", "url": None},
+        ]
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        
+        categories_despesas = [
+            {"id": 1, "nome": "Aluguel", "valor": 1000.50, "cor": "#ff0000"},
+            {"id": 2, "nome": "Supermercado de Arroz", "valor": 500.00, "cor": "#00ff00"},
+            {"id": 3, "nome": "Transporte", "valor": 150.00, "cor": "#ff6600"},
+            {"id": 4, "nome": "Internet", "valor": 120.00, "cor": "#00ffff"},
+            {"id": 5, "nome": "Saúde", "valor": 300.00, "cor": "#ff99cc"},
+        ]
 
-    categories_receitas = [
-        {"id": 6, "nome": "Salário", "valor": 5000.00, "cor": "#0000ff"},
-        {"id": 7, "nome": "Freelance", "valor": 1500.00, "cor": "#00ffcc"},
-        {"id": 8, "nome": "Investimentos", "valor": 1000.00, "cor": "#9966ff"},
-    ]
+        categories_receitas = [
+            {"id": 6, "nome": "Salário", "valor": 5000.00, "cor": "#0000ff"},
+            {"id": 7, "nome": "Freelance", "valor": 1500.00, "cor": "#00ffcc"},
+            {"id": 8, "nome": "Investimentos", "valor": 1000.00, "cor": "#9966ff"},
+        ]
 
-    categories_contas = []
+        total_cat_despesas = len(categories_despesas)
+        total_cat_receitas = len(categories_receitas)
 
-    total_cat_despesas = len(categories_despesas)
-    total_cat_receitas = len(categories_receitas)
-    total_cat_contas = len(categories_contas)
+        total_despesas = sum(float(c["valor"]) for c in categories_despesas)
+        total_receitas = sum(float(c["valor"]) for c in categories_receitas)
 
-    total_despesas = sum(float(c["valor"]) for c in categories_despesas)
-    total_receitas = sum(float(c["valor"]) for c in categories_receitas)
-    total_contas = sum(float(c["valor"]) for c in categories_contas)
-
-    breadcrumbs = [
-        {"name": "Dashboard", "url": reverse_lazy('dashboard')},
-        {"name": "Categorias", "url": None},
-    ]
-
-    context = {
-        "breadcrumbs": breadcrumbs,
-        "categories_despesas": categories_despesas,
-        "categories_receitas": categories_receitas,
-        "categories_contas": categories_contas,
-        "total_despesas": total_despesas,
-        "total_receitas": total_receitas,
-        "total_contas": total_contas,
-        "total_cat_despesas": total_cat_despesas,
-        "total_cat_receitas": total_cat_receitas,
-        "total_cat_contas": total_cat_contas,
-        "name": "categories"
-    }
-    return render(request, 'categories.html', context)
+        context.update({
+            "categories_despesas": categories_despesas,
+            "categories_receitas": categories_receitas,
+            "total_despesas": total_despesas,
+            "total_receitas": total_receitas,
+            "total_cat_despesas": total_cat_despesas,
+            "total_cat_receitas": total_cat_receitas,
+            "name": "categories"
+        })
+        
+        return context

--- a/apps/poupeai/views/categories.py
+++ b/apps/poupeai/views/categories.py
@@ -1,9 +1,12 @@
 from django.views.generic import TemplateView
 from django.urls import reverse_lazy
-from apps.poupeai.mixins import BreadcrumbMixin
+from apps.poupeai.mixins import BreadcrumbMixin, PageNameMixin
 
-class CategoriesView(BreadcrumbMixin, TemplateView):
+class CategoriesView(BreadcrumbMixin, PageNameMixin, TemplateView):
     template_name = "categories.html"
+
+    def get_name(self):
+        return "categories"
     
     def get_breadcrumbs(self):
         return [
@@ -41,7 +44,6 @@ class CategoriesView(BreadcrumbMixin, TemplateView):
             "total_receitas": total_receitas,
             "total_cat_despesas": total_cat_despesas,
             "total_cat_receitas": total_cat_receitas,
-            "name": "categories"
         })
         
         return context


### PR DESCRIPTION
## Solicitação
Implementar Mixins para reaproveitar dados compartilhados

## O que foi feito

- Desenvolvido o BreadcrumbMixin, responsável por fornecer uma lista de breadcrumbs para navegação.
- Criado o PageNameMixin, que define dinamicamente o nome da página para facilitar a identificação da seção ativa no template.
- Aplicado os mixins BreadcrumbMixin e PageNameMixin na CategoriesView.

## Impactos
Nenhum impacto relevante.